### PR TITLE
修改：获取表的列信息时指定catalog为数据库名

### DIFF
--- a/binlogportal/src/main/java/com/insistingon/binlogportal/tablemeta/TableMetaFactory.java
+++ b/binlogportal/src/main/java/com/insistingon/binlogportal/tablemeta/TableMetaFactory.java
@@ -28,7 +28,7 @@ public class TableMetaFactory {
                 String url = "jdbc:mysql://" + syncConfig.getHost() + ":" + syncConfig.getPort() + "/" + dbName;
                 connection = DriverManager.getConnection(url, syncConfig.getUserName(), syncConfig.getPassword());
                 DatabaseMetaData dbmd = connection.getMetaData();
-                ResultSet rs = dbmd.getColumns(null, dbName, tableName, null);
+                ResultSet rs = dbmd.getColumns(dbName, dbName, tableName, null);
                 TableMetaEntity tableMetaEntity = new TableMetaEntity();
                 tableMetaEntity.setTableId(tableId);
                 tableMetaEntity.setDbName(dbName);


### PR DESCRIPTION
问题：
创建数据库test，表名为user，列为ID,NAME。TableMetaFactory.getTableMetaEntity获取的表信息为mysql.user的列结构，显示结果为47列，与预期解析的test.user列结构不一致。

修改内容：
获取表信息时，指定DatabaseMetaData.getColumns方法的catalog参数，获取的列数据符合预期。

