### PR TITLE
SecureRandom.getInstanceStrong()会造成阻塞问题，

### DIFF
--- a/binlogportal/src/main/java/com/insistingon/binlogportal/BinlogPortalStarter.java
+++ b/binlogportal/src/main/java/com/insistingon/binlogportal/BinlogPortalStarter.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**

--- a/binlogportal/src/main/java/com/insistingon/binlogportal/factory/BinaryLogClientFactory.java
+++ b/binlogportal/src/main/java/com/insistingon/binlogportal/factory/BinaryLogClientFactory.java
@@ -12,7 +12,6 @@ import com.insistingon.binlogportal.position.IPositionHandler;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.RandomUtils;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -122,8 +121,8 @@ public class BinaryLogClientFactory implements IClientFactory {
 
     private long getRandomServerId() {
         try {
-            return SecureRandom.getInstanceStrong().nextLong();
-        } catch (NoSuchAlgorithmException e) {
+            return new SecureRandom().nextLong();
+        } catch (Throwable e) {
             return RandomUtils.nextLong();
         }
     }


### PR DESCRIPTION
替换为new SecureRandom().nextLong()，伪随机可满足当前场景