### PR TITLE
添加JSON类型字段特殊处理

### DIFF
--- a/binlogportal/src/main/java/com/insistingon/binlogportal/event/parser/converter/StringConverter.java
+++ b/binlogportal/src/main/java/com/insistingon/binlogportal/event/parser/converter/StringConverter.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import com.github.shyiko.mysql.binlog.event.deserialization.json.JsonBinary;
+
 public class StringConverter implements IConverter<String> {
 
     @Override
@@ -32,6 +34,15 @@ public class StringConverter implements IConverter<String> {
 
         if (Objects.equals(type, "DATE")) {
             return LocalDateTime.ofEpochSecond((Long) from / 1000, 0, ZoneOffset.ofHours(8)).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        }
+
+        // JSON类型字段特殊处理，直接转换String会乱码
+        if (type.equals("JSON")){
+            try {
+                return JsonBinary.parseAsString((byte[]) from);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         if (from.getClass() == byte[].class) {


### PR DESCRIPTION
当字段类型为`JSON`时，原有转换处理逻辑JSON字段乱码，本次更新使用`JsonBinary`处理转换